### PR TITLE
bugfix: period definition for demodulate.py

### DIFF
--- a/qubicpack/demodulate.py
+++ b/qubicpack/demodulate.py
@@ -315,7 +315,7 @@ def demodulate(self,
     calinfo = self.calsource_info()
     if given_period is None:
         if calinfo is not None and 'frequency' in calinfo['modulator'].keys():
-            period = self.calsource_info()['modulator']['frequency']
+            period = 1.0/self.calsource_info()['modulator']['frequency']
         else:
             period = 1.0
     
@@ -341,7 +341,7 @@ def demodulate(self,
     if use_calsource:
         amplitude = 0.5*(data_src.max() - data_src.min())
         if self.calsource_info() is not None:
-            period = self.calsource_info()['modulator']['frequency']
+            period = 1.0/self.calsource_info()['modulator']['frequency']
         elif given_period is None:
             period = 1.0
         else:


### PR DESCRIPTION
Modified lines 318 and 344 in demodulate.py so that the period of the sine fitting is now the inverse of the calsource frequency